### PR TITLE
Enhance/companyfile handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ company_files = myob.companyfiles.all()
 
 Render a dropdown for your user to let them select which of the company files they wish to use. Usually there will only be one against their account, but best to check. Once they've selected, prompt them for the username and password for that company file. Save this as follows:
 ```
-import base64
-
-cred.userpass = base64.b64encode(bytes('%s:%s' % (<username>, <password>), 'utf-8')).decode('utf-8')
+cred.authenticate_companyfile(company_id, <username>, <password>)
 ```
 
 Save the new `cred.state` back to your persistent storage.
@@ -121,6 +119,6 @@ If you don't know what you're looking for:
 - the repr of a `Myob` instance will yield a list of available managers (i.e. `invoices` in the above example).
 - the repr of a `Manager` instance will yield a list of available methods on that manager. Each method corresponds to an API call in MYOB.
 
-## 
+##
 
 <a name="f1">1</a>: Your users can review their partner authorisations at https://secure.myob.com/. [↩](#a1)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ A Python API around [MYOB's AccountRight API](http://developer.myob.com/api/acco
 
 This code is based off [PyXero](https://github.com/freakboy3742/pyxero) and [PyWorkflowMax](https://github.com/uptick/pyworkflowmax), providing pythonic access to the MYOB api in a similar fashion.
 
-It's not a fully fleshed out ORM, but rather a collection of namespaced functions that link up to MYOB's endpoints, though the plan is to eventually move in that direction.
-
 This project supports Python 3 only.
 
 ## Pre-getting started
@@ -87,37 +85,40 @@ from myob.credentials import PartnerCredentials
 cred = PartnerCredentials(**<persistently_saved_state_from_verified_credentials>)
 myob = Myob(cred)
 
-# Obtain list of company files. Here you will also find their IDs, which are required for other endpoints
+# Obtain list of company files. Here you will also find their IDs, which you'll need to retrieve a given company file later.
 company_files = myob.companyfiles.all()
 
+# Obtain a specific company file. Use `call=False` to just prep it for calling other endpoints without actually making a call yet at this stage.
+comp = myob.companyfiles.get(<company_id>, call=False)
+
 # Obtain a list of customers (two ways to go about this).
-customers = myob.contacts.all(company_id=<company_id>, Type='Customer')
-customers = myob.contacts.customer(company_id=<company_id>)
+customers = comp.contacts.all(Type='Customer')
+customers = comp.contacts.customer()
 
 # Obtain a list of sale invoices (two ways to go about this).
-invoices = myob.invoices.all(company_id=<company_id>, InvoiceType='Item', orderby='Number desc')
-invoices = myob.invoices.item(company_id=<company_id>, orderby='Number desc')
+invoices = comp.invoices.all(InvoiceType='Item', orderby='Number desc')
+invoices = comp.invoices.item(orderby='Number desc')
 
 # Create an invoice.
-myob.invoices.post_item(company_id=<company_id>, data=data)
+comp.invoices.post_item(data=data)
 
 # Obtain a specific invoice.
-invoice = myob.invoices.get_item(company_id=<company_id>, uid=<invoice_uid>)
+invoice = comp.invoices.get_item(uid=<invoice_uid>)
 
 # Download PDF for a specific invoice.
-invoice_pdf = myob.invoices.get_item(company_id=<company_id>, uid=<invoice_uid>, headers={'Accept': 'application/pdf'})
+invoice_pdf = comp.invoices.get_item(uid=<invoice_uid>, headers={'Accept': 'application/pdf'})
 
 # Obtain a list of tax codes.
-taxcodes = myob.general_ledger.taxcode(company_id=<company_id>)
+taxcodes = comp.general_ledger.taxcode()
 
 # Obtain a list of inventory items.
-inventory = myob.inventory.item(company_id=<company_id>)
+inventory = comp.inventory.item()
 ```
 
-If you don't know what you're looking for:
+If you don't know what you're looking for, the reprs of most objects (eg. `myob`, `comp`, `comp.invoices` above) will yield info on what managers/methods are available.
+Each method corresponds to one API call to MYOB.
 
-- the repr of a `Myob` instance will yield a list of available managers (i.e. `invoices` in the above example).
-- the repr of a `Manager` instance will yield a list of available methods on that manager. Each method corresponds to an API call in MYOB.
+Note that not all endpoints are covered here yet; we've just been adding them on an as-needed basis. If there's a particular endpoint you'd like added, please feel free to throw it into the endpoints.py file and open up a PR. All contributions are welcome and will be reviewed promptly. :)
 
 ##
 

--- a/myob/api.py
+++ b/myob/api.py
@@ -15,14 +15,14 @@ class Myob:
         self.credentials = credentials
         self.companyfiles = CompanyFiles(credentials)
         self._manager = Manager('', credentials, endpoints=[
-            (GET, 'Info', 'Return API build information for each individual endpoint.'),
+            (GET, 'Info/', 'Return API build information for each individual endpoint.'),
         ])
 
     def info(self):
         return self._manager.info()
 
     def __repr__(self):
-        return 'Myob:\n    %s' % '\n    '.join('companyfiles', 'info')
+        return 'Myob:\n    %s' % '\n    '.join(['companyfiles', 'info'])
 
 
 class CompanyFiles:
@@ -30,7 +30,7 @@ class CompanyFiles:
         self.credentials = credentials
         self._manager = Manager('', self.credentials, endpoints=[
             (ALL, '', 'Return a list of company files.'),
-            (GET, '[id]', 'List endpoints available for a company file.'),
+            (GET, '[id]/', 'List endpoints available for a company file.'),
         ])
         self._manager.name = 'CompanyFile'
 
@@ -43,7 +43,7 @@ class CompanyFiles:
             raw_companyfile = self._manager.get(id=id)['CompanyFile']
         else:
             raw_companyfile = {'Id': id}
-        return CompanyFile(raw_companyfile, id, self.credentials)
+        return CompanyFile(raw_companyfile, self.credentials)
 
     def __repr__(self):
         return self._manager.__repr__()

--- a/myob/api.py
+++ b/myob/api.py
@@ -1,7 +1,7 @@
 from .endpoints import ENDPOINTS
 from .managers import Manager
 
-class CompanyFile:
+class CompanyFiles:
     def __init__(self, credentials):
         self.credentials = credentials
         for k, v in ENDPOINTS.items():
@@ -35,7 +35,7 @@ class Myob:
                 )
             )
         self.credentials = credentials
-        self.companyfiles = CompanyFile(self.credentials)
+        self.companyfiles = CompanyFiles(self.credentials)
 
         
 

--- a/myob/api.py
+++ b/myob/api.py
@@ -1,7 +1,29 @@
 from .endpoints import ENDPOINTS
 from .managers import Manager
 
+class CompanyFile:
+    def __init__(self, credentials):
+        self.credentials = credentials
+        for k, v in ENDPOINTS.items():
+            if k == '':
+                setattr(self, 'api', Manager(k, credentials))
+                
+    
+    def get(self, id):
+        self.endpoints = self.api.get(id=id, company_id=id)
+        return Company(id, self.credentials) 
 
+    def all(self):
+        return self.api.all()
+
+
+class Company:
+    def __init__(self, id, credentials):
+        self.id = id
+        self.credentials = credentials
+        for k, v in ENDPOINTS.items():
+            if k != '':
+                setattr(self, v['plural'], Manager(k, credentials, company_id=self.id))
 class Myob:
     """An ORM-like interface to the MYOB API"""
     def __init__(self, credentials):
@@ -13,9 +35,9 @@ class Myob:
                 )
             )
         self.credentials = credentials
+        self.companyfiles = CompanyFile(self.credentials)
 
-        for k, v in ENDPOINTS.items():
-            setattr(self, v['plural'], Manager(k, credentials))
+        
 
     def __repr__(self):
         return '%s:\n    %s' % (self.__class__.__name__, '\n    '.join(

--- a/myob/credentials.py
+++ b/myob/credentials.py
@@ -1,5 +1,4 @@
-from __future__ import unicode_literals
-
+import base64
 import datetime
 
 from requests_oauthlib import OAuth2Session
@@ -12,7 +11,7 @@ class PartnerCredentials():
     def __init__(
         self, consumer_key, consumer_secret, callback_uri,
         verified=False,
-        userpass={},
+        companyfile_credentials={},
         oauth_token=None,
         refresh_token=None,
         oauth_expires_at=None,
@@ -23,7 +22,7 @@ class PartnerCredentials():
         self.callback_uri = callback_uri
 
         self.verified = verified
-        self.userpass = userpass
+        self.companyfile_credentials = companyfile_credentials
         self.oauth_token = oauth_token
         self.refresh_token = refresh_token
         self.oauth_expires_at = oauth_expires_at
@@ -32,9 +31,12 @@ class PartnerCredentials():
         url, _ = self._oauth.authorization_url(MYOB_PARTNER_BASE_URL + AUTHORIZE_URL)
         self.url = url + '&scope=CompanyFile'
 
-    def authenticate(self, companyfile=None, userpass=None):
-        if companyfile:
-            self.userpass[companyfile] = userpass
+    # TODO: Add `verify` kwarg here, which will quickly throw the provided credentials at a
+    # protected endpoint to ensure they are valid. If not, raise appropriate error.
+    def authenticate_companyfile(self, company_id, username, password):
+        """ Store hashed username-password for logging into company file. """
+        userpass = base64.b64encode(bytes('%s:%s' % (username, password), 'utf-8')).decode('utf-8')
+        self.companyfile_credentials[company_id] = userpass
 
     @property
     def state(self):
@@ -43,7 +45,7 @@ class PartnerCredentials():
             (attr, getattr(self, attr))
             for attr in (
                 'consumer_key', 'consumer_secret', 'callback_uri',
-                'verified', 'userpass', 'oauth_token', 'refresh_token',
+                'verified', 'companyfile_credentials', 'oauth_token', 'refresh_token',
                 'oauth_expires_at'
             )
             if getattr(self, attr) is not None

--- a/myob/credentials.py
+++ b/myob/credentials.py
@@ -12,7 +12,7 @@ class PartnerCredentials():
     def __init__(
         self, consumer_key, consumer_secret, callback_uri,
         verified=False,
-        userpass=None,
+        userpass={},
         oauth_token=None,
         refresh_token=None,
         oauth_expires_at=None,
@@ -31,6 +31,10 @@ class PartnerCredentials():
         self._oauth = OAuth2Session(consumer_key, redirect_uri=callback_uri)
         url, _ = self._oauth.authorization_url(MYOB_PARTNER_BASE_URL + AUTHORIZE_URL)
         self.url = url + '&scope=CompanyFile'
+
+    def authenticate(self, companyfile=None, userpass=None):
+        if companyfile:
+            self.userpass[companyfile] = userpass
 
     @property
     def state(self):

--- a/myob/credentials.py
+++ b/myob/credentials.py
@@ -6,7 +6,7 @@ from requests_oauthlib import OAuth2Session
 from .constants import ACCESS_TOKEN_URL, AUTHORIZE_URL, MYOB_PARTNER_BASE_URL
 
 
-class PartnerCredentials():
+class PartnerCredentials:
     """An object wrapping the 3-step OAuth2 process for Partner MYOB API access."""
     def __init__(
         self, consumer_key, consumer_secret, callback_uri,

--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -8,7 +8,7 @@ METHOD_ORDER = [ALL, GET, POST, PUT, DELETE]
 
 ENDPOINTS = {
     '': {
-        'plural': 'companyfiles',
+        'plural': 'company',
         'methods': [
             (ALL, '', 'Return a list of company files.'),
             (GET, '[id]/', 'List endpoints available for a company file.'),

--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -7,15 +7,7 @@ DELETE = 'DELETE'
 METHOD_ORDER = [ALL, GET, POST, PUT, DELETE]
 
 ENDPOINTS = {
-    '': {
-        'plural': 'company',
-        'methods': [
-            (ALL, '', 'Return a list of company files.'),
-            (GET, '[id]/', 'List endpoints available for a company file.'),
-            (GET, 'Info/', 'Return API build information for each individual endpoint.'),
-        ],
-    },
-    '[company_id]/Contact/': {
+    'Contact/': {
         'plural': 'contacts',
         'methods': [
             (ALL, '', 'Return all contact types for an AccountRight company file.'),
@@ -31,7 +23,7 @@ ENDPOINTS = {
             (DELETE, 'Supplier/[uid]/', 'Delete selected supplier contact.'),
         ],
     },
-    '[company_id]/Sale/Invoice/': {
+    'Sale/Invoice/': {
         'plural': 'invoices',
         'methods': [
             (ALL, '', 'Return all sale invoice types for an AccountRight company file.'),
@@ -47,7 +39,7 @@ ENDPOINTS = {
             (DELETE, 'Service/[uid]/', 'Delete selected service type sale invoice.'),
         ]
     },
-    '[company_id]/GeneralLedger/': {
+    'GeneralLedger/': {
         'plural': 'general_ledger',
         'methods': [
             (ALL, 'TaxCode/', 'Return tax codes set up with an AccountRight company file.'),
@@ -62,7 +54,7 @@ ENDPOINTS = {
             (DELETE, 'Account/[uid]/', 'Delete selected account.'),
         ]
     },
-    '[company_id]/Inventory/': {
+    'Inventory/': {
         'plural': 'inventory',
         'methods': [
             (ALL, 'Item/', 'Return inventory items for an AccountRight company file.'),
@@ -72,7 +64,7 @@ ENDPOINTS = {
             (DELETE, 'Item/[uid]/', 'Delete selected inventory item.'),
         ]
     },
-    '[company_id]/Purchase/Order/': {
+    'Purchase/Order/': {
         'plural': 'purchase_orders',
         'methods': [
             (ALL, '', 'Return all purchase order types for an AccountRight company file.'),
@@ -83,7 +75,7 @@ ENDPOINTS = {
             (DELETE, 'Item/[uid]/', 'Delete selected item type purchase order.'),
         ]
     },
-    '[company_id]/Purchase/Bill/': {
+    'Purchase/Bill/': {
         'plural': 'purchase_bills',
         'methods': [
             (ALL, '', 'Return all purchase bill types for an AccountRight company file.'),

--- a/myob/managers.py
+++ b/myob/managers.py
@@ -14,13 +14,14 @@ from .exceptions import (
 
 
 class Manager():
-    def __init__(self, name, credentials):
+    def __init__(self, name, credentials, company_id=None):
         self.credentials = credentials
         self.name = '_'.join(p for p in name.rstrip('/').split('/') if '[' not in p)
         self.base_url = MYOB_BASE_URL
         if name:
             self.base_url += name
         self.method_details = {}
+        self.company_id = company_id
 
         # Build ORM methods from given url endpoints.
         # Sort them first, to determine duplicate disambiguation order.
@@ -107,7 +108,7 @@ class Manager():
         # Build headers.
         request_kwargs['headers'] = {
             'Authorization': 'Bearer %s' % self.credentials.oauth_token,
-            'x-myobapi-cftoken': self.credentials.userpass,
+            'x-myobapi-cftoken': self.credentials.userpass.get(self.company_id),
             'x-myobapi-key': self.credentials.consumer_key,
             'x-myobapi-version': 'v2',
         }

--- a/myob/managers.py
+++ b/myob/managers.py
@@ -110,7 +110,7 @@ class Manager:
         # Build headers.
         if self.company_id:
             try:
-                companyfile_credentials = self.companyfile_credentials[self.company_id]
+                companyfile_credentials = self.credentials.companyfile_credentials[self.company_id]
             except KeyError:
                 raise KeyError('There are no stored username-password credentials for this company id.')
         else:

--- a/myob/managers.py
+++ b/myob/managers.py
@@ -106,9 +106,17 @@ class Manager():
         request_kwargs = {}
 
         # Build headers.
+        if self.company_id:
+            try:
+                companyfile_credentials = self.companyfile_credentials[self.company_id]
+            except KeyError:
+                raise KeyError('There are no stored username-password credentials for this company id.')
+        else:
+            companyfile_credentials = ''
+
         request_kwargs['headers'] = {
             'Authorization': 'Bearer %s' % self.credentials.oauth_token,
-            'x-myobapi-cftoken': self.credentials.userpass.get(self.company_id),
+            'x-myobapi-cftoken': companyfile_credentials,
             'x-myobapi-key': self.credentials.consumer_key,
             'x-myobapi-version': 'v2',
         }

--- a/myob/managers.py
+++ b/myob/managers.py
@@ -3,7 +3,7 @@ import requests
 from datetime import date
 
 from .constants import DEFAULT_PAGE_SIZE, MYOB_BASE_URL
-from .endpoints import ENDPOINTS, METHOD_ORDER
+from .endpoints import METHOD_ORDER
 from .exceptions import (
     MyobBadRequest,
     MyobExceptionUnknown,
@@ -13,11 +13,13 @@ from .exceptions import (
 )
 
 
-class Manager():
-    def __init__(self, name, credentials, company_id=None):
+class Manager:
+    def __init__(self, name, credentials, company_id=None, endpoints=[]):
         self.credentials = credentials
         self.name = '_'.join(p for p in name.rstrip('/').split('/') if '[' not in p)
         self.base_url = MYOB_BASE_URL
+        if company_id is not None:
+            self.base_url += company_id + '/'
         if name:
             self.base_url += name
         self.method_details = {}
@@ -25,8 +27,8 @@ class Manager():
 
         # Build ORM methods from given url endpoints.
         # Sort them first, to determine duplicate disambiguation order.
-        endpoints = sorted(ENDPOINTS[name]['methods'], key=lambda x: METHOD_ORDER.index(x[0]))
-        for method, endpoint, hint in endpoints:
+        sorted_endpoints = sorted(endpoints, key=lambda x: METHOD_ORDER.index(x[0]))
+        for method, endpoint, hint in sorted_endpoints:
             self.build_method(method, endpoint, hint)
 
     def build_method(self, method, endpoint, hint):


### PR DESCRIPTION
Resolves #7 (to a sufficient extent)

- Added support for storing multiple sets of companyfile credentials.
- Removed need to pass `company_id` into every single method, through a slight ORM-ification of the `CompanyFile` objects.
- base64 conversion of the userpass is now done internally, rather asking the user to do it. Just call the new `cred.authenticate_companyfile(company_id, username, password)` method.
- Updated README to cover all of the above changes. Read that for a usage walkthrough of the new setup.