### PR TITLE
fix issue where client_id and client_secret were not sent to myob dur…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+.idea

--- a/myob/credentials.py
+++ b/myob/credentials.py
@@ -71,6 +71,7 @@ class PartnerCredentials:
             MYOB_PARTNER_BASE_URL + ACCESS_TOKEN_URL,
             code=code,
             client_secret=self.consumer_secret,
+            include_client_id=True,
         )
         self.save_token(token)
 


### PR DESCRIPTION
…ing verification

MYOB's API requires that we pass along the client_id and client_secret with the verification request. Until recently this was done by default in requests_oauthlib however now we need to use `include_client_id=True` when using the `fetch_token` method. Prior to this PR the library is incompatible with the latest versions of requests_oauthlib.