### PR TITLE
Add transaction endpoints

### DIFF
--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -7,6 +7,22 @@ DELETE = 'DELETE'
 METHOD_ORDER = [ALL, GET, POST, PUT, DELETE]
 
 ENDPOINTS = {
+    'Banking/': {
+        'plural': 'banking',
+        'methods': [
+            (ALL, '', 'Return all banking types for an AccountRight company file.'),
+            (ALL, 'SpendMoneyTxn/', 'Return all spendmoneytxns for an AccountRight company file.'),
+            (GET, 'SpendMoneyTxn/[uid]/', 'Return selected spendmoneytxn.'),
+            (PUT, 'SpendMoneyTxn/[uid]/', 'Update selected spendmoneytxn.'),
+            (POST, 'SpendMoneyTxn/', 'Create new spendmoneytxn.'),
+            (DELETE, 'SpendMoneyTxn/[uid]/', 'Delete selected spendmoneytxn.'),
+            (ALL, 'ReceiveMoneyTxn/', 'Return all receivemoneytxns for an AccountRight company file.'),
+            (GET, 'ReceiveMoneyTxn/[uid]/', 'Return selected receivemoneytxn.'),
+            (PUT, 'ReceiveMoneyTxn/[uid]/', 'Update selected receivemoneytxn.'),
+            (POST, 'ReceiveMoneyTxn/', 'Create new receivemoneytxn.'),
+            (DELETE, 'ReceiveMoneyTxn/[uid]/', 'Delete selected receivemoneytxn.'),
+        ],
+    },
     'Contact/': {
         'plural': 'contacts',
         'methods': [

--- a/tests/endpoints.py
+++ b/tests/endpoints.py
@@ -27,8 +27,6 @@ class EndpointTests(TestCase):
             'x-myobapi-version': 'v2'
         }
 
-        self.maxDiff = None
-
     @patch('myob.managers.requests.request')
     def assertEndpointReached(self, func, params, method, endpoint, mock_request, timeout=None):
         mock_request.return_value.status_code = 200

--- a/tests/endpoints.py
+++ b/tests/endpoints.py
@@ -27,6 +27,8 @@ class EndpointTests(TestCase):
             'x-myobapi-version': 'v2'
         }
 
+        self.maxDiff = None
+
     @patch('myob.managers.requests.request')
     def assertEndpointReached(self, func, params, method, endpoint, mock_request, timeout=None):
         mock_request.return_value.status_code = 200
@@ -68,6 +70,7 @@ class EndpointTests(TestCase):
     def test_companyfile(self):
         self.assertEqual(repr(self.companyfile), (
             "CompanyFile:\n"
+            "    banking\n"
             "    contacts\n"
             "    general_ledger\n"
             "    inventory\n"
@@ -75,6 +78,33 @@ class EndpointTests(TestCase):
             "    purchase_bills\n"
             "    purchase_orders"
         ))
+
+    def test_banking(self):
+        self.assertEqual(repr(self.companyfile.banking), (
+            "BankingManager:\n"
+            "                             all() - Return all banking types for an AccountRight company file.\n"
+            "       delete_receivemoneytxn(uid) - Delete selected receivemoneytxn.\n"
+            "         delete_spendmoneytxn(uid) - Delete selected spendmoneytxn.\n"
+            "          get_receivemoneytxn(uid) - Return selected receivemoneytxn.\n"
+            "            get_spendmoneytxn(uid) - Return selected spendmoneytxn.\n"
+            "        post_receivemoneytxn(data) - Create new receivemoneytxn.\n"
+            "          post_spendmoneytxn(data) - Create new spendmoneytxn.\n"
+            "    put_receivemoneytxn(uid, data) - Update selected receivemoneytxn.\n"
+            "      put_spendmoneytxn(uid, data) - Update selected spendmoneytxn.\n"
+            "                 receivemoneytxn() - Return all receivemoneytxns for an AccountRight company file.\n"
+            "                   spendmoneytxn() - Return all spendmoneytxns for an AccountRight company file."
+        ))
+        self.assertEndpointReached(self.companyfile.banking.all, {}, 'GET', f'/{CID}/Banking/')
+        self.assertEndpointReached(self.companyfile.banking.spendmoneytxn, {}, 'GET', f'/{CID}/Banking/SpendMoneyTxn/')
+        self.assertEndpointReached(self.companyfile.banking.get_spendmoneytxn, {'uid': UID}, 'GET', f'/{CID}/Banking/SpendMoneyTxn/{UID}/')
+        self.assertEndpointReached(self.companyfile.banking.put_spendmoneytxn, {'uid': UID, 'data': DATA}, 'PUT', f'/{CID}/Banking/SpendMoneyTxn/{UID}/')
+        self.assertEndpointReached(self.companyfile.banking.post_spendmoneytxn, {'data': DATA}, 'POST', f'/{CID}/Banking/SpendMoneyTxn/')
+        self.assertEndpointReached(self.companyfile.banking.delete_spendmoneytxn, {'uid': UID}, 'DELETE', f'/{CID}/Banking/SpendMoneyTxn/{UID}/')
+        self.assertEndpointReached(self.companyfile.banking.receivemoneytxn, {}, 'GET', f'/{CID}/Banking/ReceiveMoneyTxn/')
+        self.assertEndpointReached(self.companyfile.banking.get_receivemoneytxn, {'uid': UID}, 'GET', f'/{CID}/Banking/ReceiveMoneyTxn/{UID}/')
+        self.assertEndpointReached(self.companyfile.banking.put_receivemoneytxn, {'uid': UID, 'data': DATA}, 'PUT', f'/{CID}/Banking/ReceiveMoneyTxn/{UID}/')
+        self.assertEndpointReached(self.companyfile.banking.post_receivemoneytxn, {'data': DATA}, 'POST', f'/{CID}/Banking/ReceiveMoneyTxn/')
+        self.assertEndpointReached(self.companyfile.banking.delete_receivemoneytxn, {'uid': UID}, 'DELETE', f'/{CID}/Banking/ReceiveMoneyTxn/{UID}/')
 
     def test_contacts(self):
         self.assertEqual(repr(self.companyfile.contacts), (


### PR DESCRIPTION
I needed the Spend and Receive transaction endpoints from the banking API so I have implemented them in this PR. Please let me know if there are any further changes you need before merging.