### PR TITLE
Handle response if MYOB does not return content-type

### DIFF
--- a/myob/managers.py
+++ b/myob/managers.py
@@ -72,7 +72,7 @@ class Manager:
 
             if response.status_code == 200:
                 # We don't want to be deserialising binary responses..
-                if not response.headers['content-type'].startswith('application/json'):
+                if not response.headers.get('content-type', '').startswith('application/json'):
                     return response.content
 
                 return response.json()


### PR DESCRIPTION
When deleting a transaction `companyfile.banking.delete_spendmoneytxn(uid=uuid)`, MYOB does not return a `content-type` in the response and the Manager raises a `KeyError`.

