### PR TITLE
Adding support for company preferences endpoint

### DIFF
--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -107,4 +107,10 @@ ENDPOINTS = {
             (DELETE, 'Service/[uid]/', 'Delete selected service type purchase bill.'),
         ]
     },
+    'Company/': {
+        'plural': 'company',
+        'methods': [
+            (ALL, 'Preferences/', 'Return company data file preferences for an AccountRight company file.')
+        ]
+    },
 }

--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -74,9 +74,9 @@ ENDPOINTS = {
         ]
     },
     'Company/': {
-        'plural': 'company',
+        'name': 'company',
         'methods': [
-            (ALL, 'Preferences/', 'Return company data file preferences for an AccountRight company file.')
+            (ALL, 'Preferences/', 'company data file preference')
         ]
     },
 }

--- a/myob/managers.py
+++ b/myob/managers.py
@@ -72,7 +72,7 @@ class Manager:
 
             if response.status_code == 200:
                 # We don't want to be deserialising binary responses..
-                if not response.headers['content-type'].startswith('application/json'):
+                if not response.headers.get('content-type', '').startswith('application/json'):
                     return response.content
 
                 return response.json()

--- a/tests/endpoints.py
+++ b/tests/endpoints.py
@@ -69,6 +69,7 @@ class EndpointTests(TestCase):
         self.assertEqual(repr(self.companyfile), (
             "CompanyFile:\n"
             "    banking\n"
+            "    company\n"
             "    contacts\n"
             "    general_ledger\n"
             "    inventory\n"
@@ -241,6 +242,13 @@ class EndpointTests(TestCase):
         self.assertEndpointReached(self.companyfile.purchase_bills.put_service, {'uid': UID, 'data': DATA}, 'PUT', f'/{CID}/Purchase/Bill/Service/{UID}/')
         self.assertEndpointReached(self.companyfile.purchase_bills.post_service, {'data': DATA}, 'POST', f'/{CID}/Purchase/Bill/Service/')
         self.assertEndpointReached(self.companyfile.purchase_bills.delete_service, {'uid': UID}, 'DELETE', f'/{CID}/Purchase/Bill/Service/{UID}/')
+
+    def test_company(self):
+        self.assertEqual(repr(self.companyfile.company), (
+            "CompanyManager:\n"
+            "    preferences() - Return company data file preferences for an AccountRight company file."
+        ))
+        self.assertEndpointReached(self.companyfile.company.preferences, {}, 'GET', f'/{CID}/Company/Preferences/')
 
     def test_timeout(self):
         self.assertEndpointReached(self.companyfile.contacts.all, {'timeout': 5}, 'GET', f'/{CID}/Contact/', timeout=5)

--- a/tests/endpoints.py
+++ b/tests/endpoints.py
@@ -301,7 +301,7 @@ class EndpointTests(TestCase):
     def test_company(self):
         self.assertEqual(repr(self.companyfile.company), (
             "CompanyManager:\n"
-            "    preferences() - Return company data file preferences for an AccountRight company file."
+            "    preferences() - Return all company data file preferences for an AccountRight company file."
         ))
         self.assertEndpointReached(self.companyfile.company.preferences, {}, 'GET', f'/{CID}/Company/Preferences/')
 


### PR DESCRIPTION
Company preferences contains general settings for the MYOB company file. Our use case is to fetch the TransactionsCannotBeChangedMustBeReversed system setting so we know how to handle transaction updates.