### PR TITLE
Patch for expired check

### DIFF
--- a/myob/credentials.py
+++ b/myob/credentials.py
@@ -53,7 +53,6 @@ class PartnerCredentials:
 
     def expired(self, now=None):
         """ Determine whether the current access token has expired. """
-        
         # Expiry might be unset if the user hasn't finished authenticating.
         if self.oauth_expires_at is None:
             return False

--- a/myob/credentials.py
+++ b/myob/credentials.py
@@ -53,6 +53,7 @@ class PartnerCredentials:
 
     def expired(self, now=None):
         """ Determine whether the current access token has expired. """
+        
         # Expiry might be unset if the user hasn't finished authenticating.
         if self.oauth_expires_at is None:
             return False
@@ -62,6 +63,7 @@ class PartnerCredentials:
         # they can use self.oauth_expires_at
         CONSERVATIVE_SECONDS = 30
 
+        self.oauth_expires_at = datetime.datetime.strptime(self.oauth_expires_at, "%Y-%m-%dT%H:%M:%S.%f")
         now = now or datetime.datetime.now()
         return self.oauth_expires_at <= (now + datetime.timedelta(seconds=CONSERVATIVE_SECONDS))
 


### PR DESCRIPTION
I would like to check if a token has expired and then refresh it if it has, however when checking expiry the `self.oauth_expires_at` is a string so gives a `TypeError`.  This PR converts the `self.oauth_expires_at` back to a date so `return self.oauth_expires_at <= (now + datetime.timedelta(seconds=CONSERVATIVE_SECONDS))` doesn't fail.