### PR TITLE
Add endpoints and tests for Sale/CustomerPayment

### DIFF
--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -31,7 +31,10 @@ ENDPOINTS = {
     'Sale/CustomerPayment/': {
         'name': 'customer_payments',
         'methods': [
-            (ALL, '', 'sale customer payment type')
+            (ALL,    '', 'sale customer payment type'),
+            (GET,    '', 'sale customer payment'),
+            (POST,   '', 'sale customer payment'),
+            (DELETE, '', 'sale customer payment'),
         ]
     },
     'Sale/Invoice/': {

--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -31,7 +31,7 @@ ENDPOINTS = {
     'Sale/CustomerPayment/': {
         'name': 'customer_payments',
         'methods': [
-            (ALL,    '', 'sale customer payment type'),
+            (ALL, '', 'sale customer payment'),
             (GET,    '', 'sale customer payment'),
             (POST,   '', 'sale customer payment'),
             (DELETE, '', 'sale customer payment'),

--- a/myob/endpoints.py
+++ b/myob/endpoints.py
@@ -32,8 +32,8 @@ ENDPOINTS = {
         'name': 'customer_payments',
         'methods': [
             (ALL, '', 'sale customer payment'),
-            (GET,    '', 'sale customer payment'),
-            (POST,   '', 'sale customer payment'),
+            (GET, '', 'sale customer payment'),
+            (POST, '', 'sale customer payment'),
             (DELETE, '', 'sale customer payment'),
         ]
     },

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -202,7 +202,10 @@ class EndpointTests(TestCase):
     def test_customer_payments(self):
         self.assertEqual(repr(self.companyfile.customer_payments), (
             "Sale_CustomerPaymentManager:\n"
-            "    all() - Return all sale customer payment types for an AccountRight company file."
+            "          all() - Return all sale customer payments for an AccountRight company file.\n"
+            "    delete(uid) - Delete selected sale customer payment.\n"
+            "       get(uid) - Return selected sale customer payment.\n"
+            "     post(data) - Create new sale customer payment."
         ))
         self.assertEndpointReached(self.companyfile.customer_payments.all, {}, 'GET', f'/{CID}/Sale/CustomerPayment/')
 


### PR DESCRIPTION
Supersedes PR #62 by fixing tests; Sorry if this is the wrong way to update someone else's PR — thought it best to take a stab at it and learn from a mistake if not.

@HHry0918 has added endpoints for [Sale/CustomerPayment (docs)](Sale/CustomerPayment)