### PR TITLE
renovate pin digests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
           - "3.13"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install deps & the package itself

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "pinDigests": true
 }


### PR DESCRIPTION
**Changes**
- Add pinDigests: true to renovate.json
- Pin existing GitHub Actions in lint.yml and test.yml to full commit SHAs

**Why**
  A repo-level GitHub Actions policy requires all actions to be pinned to a full commit SHA. This was causing Renovate to thrash on PR #114 — CI would fail immediately on every Renovate PR (because Renovate uses tag-based refs like @v4.0.0 by default), Renovate would see the failure ~30 minutes later and autoclose the PR, then reopen it on the next hourly run. This has been looping since the policy was introduced.

pinDigests: true tells Renovate to use commit SHAs instead of tags (e.g. astral-sh/ruff-action@abc123 # v4.0.0), satisfying the policy so CI passes. The workflow files are also updated so master itself is compliant — previously the actions there were also violating the policy but not being flagged since they weren't in an open PR.